### PR TITLE
Automatic config backup and restore

### DIFF
--- a/configs/internal/minimal.json
+++ b/configs/internal/minimal.json
@@ -14,8 +14,7 @@
 	},
 	"cameras": {
 		"front": {
-			"enabled": true,
-			"id": 1
+			"enabled": false
 		},
 		"back": {
 			"enabled": false
@@ -29,31 +28,22 @@
 	},
 	"sensors": {
 		"memory": {
-			"enabled": true,
-			"frequency": 3
+			"enabled": false
 		},
 		"cpu_temp": {
-			"enabled": true,
-			"frequency": 5
+			"enabled": false
 		},
 		"thermal_camera": {
-			"enabled": true,
-			"frequency": 0.5,
-			"width": 32,
-			"height": 24
+			"enabled": false
 		},
 		"temperature": {
-			"enabled": true,
-			"frequency": 2,
-			"address": "0x5A"
+			"enabled": false
 		},
 		"distance": {
-			"enabled": true,
-			"frequency": 2
+			"enabled": false
 		},
 		"gas": {
-			"enabled": true,
-			"frequency": 2
+			"enabled": false
 		}
 	},
 	"debug": {

--- a/configs/internal/minimal.json
+++ b/configs/internal/minimal.json
@@ -1,0 +1,62 @@
+{
+	"network": {
+		"ip": "*"
+	},
+	"control": {
+		"default_gamepad_speed": 3,
+		"default_keyboard_speed": 3
+	},
+	"motors": {
+		"type": "virtual"
+	},
+	"arduino": {
+		"enabled": false
+	},
+	"cameras": {
+		"front": {
+			"enabled": true,
+			"id": 1
+		},
+		"back": {
+			"enabled": false
+		},
+		"left": {
+			"enabled": false
+		},
+		"right": {
+			"enabled": false
+		}
+	},
+	"sensors": {
+		"memory": {
+			"enabled": true,
+			"frequency": 3
+		},
+		"cpu_temp": {
+			"enabled": true,
+			"frequency": 5
+		},
+		"thermal_camera": {
+			"enabled": true,
+			"frequency": 0.5,
+			"width": 32,
+			"height": 24
+		},
+		"temperature": {
+			"enabled": true,
+			"frequency": 2,
+			"address": "0x5A"
+		},
+		"distance": {
+			"enabled": true,
+			"frequency": 2
+		},
+		"gas": {
+			"enabled": true,
+			"frequency": 2
+		}
+	},
+	"debug": {
+		"print_messages": true
+	}
+}

--- a/control_receiver.py
+++ b/control_receiver.py
@@ -111,7 +111,7 @@ class ControlReceiver (WebSocketProcess):
                     new_id = str(id+1)
                     os.rename(dir+"/"+file, dir+"/"+name+".backup."+new_id)
         # Save the previous config as a new backup
-        os.rename(dir + "/" + name, dir + "/" + name + ".backup." + str(0))
+        os.rename(dir + "/" + name, dir + "/" + name + ".backup.0")
 
         # Save new config to file
         with open(self.config_file, 'w') as f:

--- a/control_receiver.py
+++ b/control_receiver.py
@@ -96,7 +96,7 @@ class ControlReceiver (WebSocketProcess):
 
     def save_config(self, cfg):
         # Rolling backups
-        dir = os.path.dirname(self.config_file)
+        config_dir = os.path.dirname(self.config_file)
         name = os.path.basename(self.config_file)
         # Find existing backups for this config file
         for file in sorted(os.listdir(dir), reverse=True):

--- a/control_receiver.py
+++ b/control_receiver.py
@@ -95,6 +95,24 @@ class ControlReceiver (WebSocketProcess):
                 self.pipe.send(["SYNC_SPEED", "kb", self.servo_party.keyboard_speed])
 
     def save_config(self, cfg):
+        # Rolling backups
+        dir = os.path.dirname(self.config_file)
+        name = os.path.basename(self.config_file)
+        # Find existing backups for this config file
+        for file in sorted(os.listdir(dir), reverse=True):
+            if file.startswith(f"{name}.backup."):
+                # Get backup ID
+                id = int(file[-1])
+                # Remove oldest backup
+                if id == 5:
+                    os.remove(dir+"/"+file)
+                else:
+                    # Add 1 to the rest of the backup IDs
+                    new_id = str(id+1)
+                    os.rename(dir+"/"+file, dir+"/"+name+".backup."+new_id)
+        # Save the previous config as a new backup
+        os.rename(dir + "/" + name, dir + "/" + name + ".backup." + str(0))
+
         # Save new config to file
         with open(self.config_file, 'w') as f:
             f.write(cfg)

--- a/control_receiver.py
+++ b/control_receiver.py
@@ -99,19 +99,19 @@ class ControlReceiver (WebSocketProcess):
         config_dir = os.path.dirname(self.config_file)
         name = os.path.basename(self.config_file)
         # Find existing backups for this config file
-        for file in sorted(os.listdir(dir), reverse=True):
+        for file in sorted(os.listdir(config_dir), reverse=True):
             if file.startswith(f"{name}.backup."):
                 # Get backup ID
                 id = int(file[-1])
                 # Remove oldest backup
                 if id == 5:
-                    os.remove(dir+"/"+file)
+                    os.remove(config_dir+"/"+file)
                 else:
                     # Add 1 to the rest of the backup IDs
                     new_id = str(id+1)
-                    os.rename(dir+"/"+file, dir+"/"+name+".backup."+new_id)
+                    os.rename(config_dir+"/"+file, config_dir+"/"+name+".backup."+new_id)
         # Save the previous config as a new backup
-        os.rename(dir + "/" + name, dir + "/" + name + ".backup.0")
+        os.rename(config_dir + "/" + name, config_dir + "/" + name + ".backup.0")
 
         # Save new config to file
         with open(self.config_file, 'w') as f:

--- a/manager.py
+++ b/manager.py
@@ -111,7 +111,7 @@ if __name__ == '__main__':
         config_dir = os.path.dirname(default_config)
         name = os.path.basename(default_config)
         # Keep a copy of the invalid config for the user to review
-        os.rename(dir + "/" + name, dir + "/last_invalid_config.json")
+        os.rename(config_dir + "/" + name, config_dir + "/last_invalid_config.json")
         logger.warning("Config error! Review your last_invalid_config.json")
         # Find existing backups for this config file
         for file in sorted(os.listdir(dir)):
@@ -120,11 +120,11 @@ if __name__ == '__main__':
                 id = int(file[-1])
                 if id == 0:
                     # Replace invalid config with most recent backup
-                    os.rename(dir + "/" + name + ".backup.0", dir + "/" + name)
+                    os.rename(config_dir + "/" + name + ".backup.0", config_dir + "/" + name)
                     logger.warning(f"Restored {name} config from backup.")
                 else:
                     # Subtract 1 from the rest of the backup IDs
                     new_id = str(id - 1)
-                    os.rename(dir + "/" + file, dir + "/" + name + ".backup." + new_id)
+                    os.rename(config_dir + "/" + file, config_dir + "/" + name + ".backup." + new_id)
     else:
         logger.info("All processes ended")

--- a/manager.py
+++ b/manager.py
@@ -108,8 +108,11 @@ if __name__ == '__main__':
             logger.info("Going to restart")
     except KeyError:
         # Restore rolling backups when there is a config error
-        dir = os.path.dirname(default_config)
+        config_dir = os.path.dirname(default_config)
         name = os.path.basename(default_config)
+        # Keep a copy of the invalid config for the user to review
+        os.rename(dir + "/" + name, dir + "/last_invalid_config.json")
+        logger.warning("Config error! Review your last_invalid_config.json")
         # Find existing backups for this config file
         for file in sorted(os.listdir(dir)):
             if file.startswith(f"{name}.backup."):
@@ -118,10 +121,10 @@ if __name__ == '__main__':
                 if id == 0:
                     # Replace invalid config with most recent backup
                     os.rename(dir + "/" + name + ".backup.0", dir + "/" + name)
+                    logger.warning(f"Restored {name} config from backup.")
                 else:
                     # Subtract 1 from the rest of the backup IDs
                     new_id = str(id - 1)
                     os.rename(dir + "/" + file, dir + "/" + name + ".backup." + new_id)
-
     else:
         logger.info("All processes ended")

--- a/manager.py
+++ b/manager.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import json
 from multiprocessing import Pipe
 from argparse import ArgumentParser
 from control_receiver import ControlReceiver
@@ -106,7 +107,7 @@ if __name__ == '__main__':
     try:
         while(manager.run()):
             logger.info("Going to restart")
-    except KeyError:
+    except (KeyError, json.decoder.JSONDecodeError):
         # Restore rolling backups when there is a config error
         config_dir = os.path.dirname(default_config)
         name = os.path.basename(default_config)

--- a/manager.py
+++ b/manager.py
@@ -129,5 +129,9 @@ if __name__ == '__main__':
                         # Subtract 1 from the rest of the backup IDs
                         new_id = str(id - 1)
                         os.rename(config_dir + "/" + file, config_dir + "/" + name + ".backup." + new_id)
+        # If all else fails enter "safe mode" with a minimal known valid config
+        if not any(name in file for file in os.listdir(config_dir)):
+            logger.warning("No backups to restore, entering safe mode with minimal config.")
+            os.popen(f"cp {config_dir}/internal/minimal.json {config_dir}/{name}")
     else:
         logger.info("All processes ended")

--- a/sensor_wrapper.py
+++ b/sensor_wrapper.py
@@ -31,9 +31,9 @@ class SensorWrapper:
                 self.logger.warning(f"Frequency for {self._key} sensor not set! Check your config.")
                 self.frequency = 1
                 self.logger.info(f"Set frequency for {self._key} sensor to default: {self.frequency}.")
-            else:
-                # Sensor is disabled. Frequency is still required.
-                self.frequency = -1
+        else:
+            # Sensor is disabled. Frequency is still required.
+            self.frequency = -1
 
     def get_data(self):
         return None


### PR DESCRIPTION
The user is given a lot of opportunity to break the robot when they're playing around with config files.
This pull request stops that! Well, it stops the breaking, not the playing.

When a new config is received from the interface by the `ControlReceiver`, the old config file is stored as a backup.

Then, if the robot encounters an error when either parsing the JSON file or traversing the DOM of an already parsed file, the most recent backup is restored.
A copy of the user's invalid config file is kept for them to review. They can fix and restore it via the SSH terminal, or continue to use the restored backup.

Since it is possible for the user to save a config file multiple times before restarting the service, an arbitrary number of backups are kept.
If backups have been deleted, they are skipped.
If there are no backups remaining, the robot enters “Safe mode” loading a known good config with virtual motors, no enabled sensors and minimal fields.


Demonstration:
https://www.youtube.com/watch?v=kqPMhK3IF3A
