### PR TITLE
Added Supervisord init script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -176,16 +176,14 @@ install_supervisor () {
     echo -e "\nInstalling Supervisor SIGHTS extension..."
     python3 -m pip install ./supervisor_sights_config
 
-    echo -e "\nAdding supervisord to /etc/rc.local..."
-    if grep -Fxq "supervisord &" /etc/rc.local
-    then
-        echo -e "Already done..."
-    else
-        sed -i -e '$i \supervisord &\n' /etc/rc.local
-    fi
+    echo -e "\nInstalling Supervisor init script"
+    cp SIGHTSRobot/src/configs/systemd/supervisord /etc/init.d/
+    chmod 755 /etc/init.d/supervisord
+    chown root:root /etc/init.d/supervisord
 
     echo -e "\nRunning Supervisor"
-    supervisord
+    /etc/init.d/supervisord start
+    
     echo
     print_detected_ip ":9001/"
 }

--- a/install.sh
+++ b/install.sh
@@ -180,6 +180,7 @@ install_supervisor () {
     cp SIGHTSRobot/src/configs/systemd/supervisord /etc/init.d/
     chmod 755 /etc/init.d/supervisord
     chown root:root /etc/init.d/supervisord
+    update-rc.d supervisord defaults
 
     echo -e "\nRunning Supervisor"
     /etc/init.d/supervisord start

--- a/install.sh
+++ b/install.sh
@@ -210,7 +210,11 @@ update () {
     cd ..
     python3 -m pip install ./supervisor_sights_config
 
-    echo -e "Update complete!"
+    echo -e "\nRestarting Supervisord and SIGHTS..."
+    service supervisord restart
+    #supervisord restart sights
+
+    echo -e "\nUpdate complete!"
     echo
     print_detected_ip "/"
 }

--- a/src/configs/supervisor/supervisord.conf
+++ b/src/configs/supervisor/supervisord.conf
@@ -10,7 +10,7 @@
 
 ; Required for systemctl to work
 [unix_http_server]
-file=/opt/sights/supervisor.sock   ; (the path to the socket file)
+file=/var/run/supervisor.sock   ; (the path to the socket file)
 
 ; inet (TCP) server, required to use XML-RPC API
 [inet_http_server]               
@@ -19,7 +19,7 @@ port=*:9001                      ; (ip_address:port specifier, *:port for all if
 ; Configuration for supervisord
 [supervisord]
 logfile=/opt/sights/supervisord.log ; (main log file;default $CWD/supervisord.log)
-pidfile=/opt/sights/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+pidfile=/var/run/supervisord.pid  ; (supervisord pidfile;default supervisord.pid)
 logfile_maxbytes=50MB             ; (max main logfile bytes b4 rotation;default 50MB)
 logfile_backups=10                ; (num of main logfile rotation backups;default 10)
 loglevel=info                     ; (log level;default info; others: debug,warn,trace)
@@ -29,7 +29,7 @@ minprocs=200                      ; (min. avail process descriptors;default 200)
 
 ; The interface socket. Allows supervisorctl to communicate with supervisord
 [supervisorctl]
-serverurl=unix:///opt/sights/supervisor.sock ; use a unix:// URL  for a unix socket
+serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
 
 ; This section must remain in the config file for (supervisorctl/web interface) to work
 [rpcinterface:supervisor]

--- a/src/configs/systemd/supervisord
+++ b/src/configs/systemd/supervisord
@@ -1,0 +1,164 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          supervisord
+# Required-Start:    $local_fs $remote_fs $networking
+# Required-Stop:     $local_fs $remote_fs $networking
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts supervisord - see http://supervisord.org
+# Description:       Starts and stops supervisord as needed - see http://supervisord.org
+### END INIT INFO
+
+# Author: Leonard Norrgard <leonard.norrgard@refactor.fi>
+# Version 1.0-alpha
+# Based on the /etc/init.d/skeleton script in Debian.
+
+# Very minor edits by the Semi-Autonomous Rescue Team to correct $DAEMON path
+
+# Please note: This script is not yet well tested. What little testing
+# that actually was done was only on supervisor 2.2b1.
+
+# Do NOT "set -e"
+
+# PATH should only include /usr/* if it runs after the mountnfs.sh script
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="Run a set of applications as daemons."
+NAME=supervisord
+DAEMON=/usr/local/bin/$NAME   # Supervisord is installed in /usr/bin by default, but /usr/sbin would make more sense.
+SUPERVISORCTL=/usr/local/bin/supervisorctl
+PIDFILE=/var/run/$NAME.pid
+DAEMON_ARGS="--pidfile ${PIDFILE}"
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
+. /lib/lsb/init-functions
+
+#
+# Function that starts the daemon/service
+#
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+        [ -e $PIDFILE ] && return 1
+
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+		$DAEMON_ARGS \
+		|| return 2
+	# Add code here, if necessary, that waits for the process to be ready
+	# to handle requests from services started subsequently which depend
+	# on this one.  As a last resort, sleep for some time.
+}
+
+#
+# Function that stops the daemon/service
+#
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+        [ -e $PIDFILE ] || return 1
+
+	# Stop all processes under supervisord control.
+	$SUPERVISORCTL stop all
+
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $NAME
+	RETVAL="$?"
+	[ "$RETVAL" = 2 ] && return 2
+	# Wait for children to finish too if this is a daemon that forks
+	# and if the daemon is only ever run from this initscript.
+	# If the above conditions are not satisfied then add some other code
+	# that waits for the process to drop all resources that could be
+	# needed by services started subsequently.  A last resort is to
+	# sleep for some time.
+	start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
+	[ "$?" = 2 ] && return 2
+	# Many daemons don't delete their pidfiles when they exit.
+	rm -f $PIDFILE
+	return "$RETVAL"
+}
+
+#
+# Function that sends a SIGHUP to the daemon/service
+#
+do_reload() {
+	#
+	# If the daemon can reload its configuration without
+	# restarting (for example, when it is sent a SIGHUP),
+	# then implement that here.
+	#
+	start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $NAME
+	return 0
+}
+
+case "$1" in
+  start)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  stop)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  #reload|force-reload)
+	#
+	# If do_reload() is not implemented then leave this commented out
+	# and leave 'force-reload' as an alias for 'restart'.
+	#
+	#log_daemon_msg "Reloading $DESC" "$NAME"
+	#do_reload
+	#log_end_msg $?
+	#;;
+  restart|force-reload)
+	#
+	# If the "reload" option is implemented then remove the
+	# 'force-reload' alias
+	#
+	log_daemon_msg "Restarting $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	  0|1)
+		do_start
+		case "$?" in
+			0) log_end_msg 0 ;;
+			1) log_end_msg 1 ;; # Old process is still running
+			*) log_end_msg 1 ;; # Failed to start
+		esac
+		;;
+	  *)
+	  	# Failed to stop
+		log_end_msg 1
+		;;
+	esac
+	;;
+  *)
+	#echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
+	echo "Usage: $SCRIPTNAME {start|stop|restart|force-reload}" >&2
+	exit 3
+	;;
+esac
+
+:


### PR DESCRIPTION
# Description

Adds a systemd init script for Supervisor. No more dodgy `/etc/rc.local` usage.

This should work for Debian, and hopefully Ubuntu as well.

The script is based on the user-submitted init scripts here, but I've have to change a single variable to point to Supervisor's actual path.

Closes #24 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Re-write of an existing feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Testing

It's working fine on a Raspberry Pi 3B+ running Raspbian Buster. Unfortunately it won't work under WSL since systemd is not implemented fully.

I will test it on a NUC running Debian. If someone could test it on Ubuntu, that would be wonderful.

# Final checklist:
- [x] Code follows the style guidelines of SIGHTS
- [x] I have performed a self-review of my own code
- [ ] Comments have been added, particularly in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [x] The changes cause no new errors or warnings
