### PR TITLE
Use older versions of Adafruit_AMG88x and bitfield

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,6 +4,7 @@ websockets>=7.0
 pyserial>=3.4
 PySGP30
 PyMLX90614
-Adafruit_AMG88xx
+git+https://github.com/adafruit/Adafruit_AMG88xx_python#egg=Adafruit_AMG88xx
+git+https://github.com/adafruit/Adafruit_bitfield_python#egg=Adafruit_bitfield
 smbus2
 multiprocessing-logging


### PR DESCRIPTION
# Description

Closes/Fixes https://github.com/SFXRescue/SIGHTSRobot/pull/38#discussion_r360372867

TL;DR, `ModuleNotFoundError` when using the current requirements.txt. To be merged back into the `sensor-rewrite` branch (#38).

**Why was the issue not spotted earlier?**
These old libraries are still installed on my old machine. I assume the same is true for you, dear reader*.

**Why on earth are you making a pull request for two lines?**
So it can be tested, since I can't be sure why it is working on other development environments.

**Why are you awake at 3:55 AM?**
Why are _you_ awake at 3:55 AM?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Re-write of an existing feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Testing

An hour of uninstalling and reinstalling various versions of these libraries until I could be confident in my ability to use pip.

# Final checklist:

- [x] Code follows the style guidelines of SIGHTS
- [x] I have performed a self-review of my own code
- [x] Comments have been added, particularly in hard-to-understand areas
- [x] Made corresponding changes to the documentation
- [x] The changes cause no new errors or warnings

* If, of course, you, dear reader, installed the libraries.